### PR TITLE
feat: Add headless option for UI command

### DIFF
--- a/src/commands/ui.rs
+++ b/src/commands/ui.rs
@@ -3,13 +3,18 @@ use std::net::IpAddr;
 use agentdev::web::{ServerOptions, run_blocking};
 use anyhow::Result;
 
-pub fn handle_ui(port: u16, host: Option<IpAddr>) -> Result<()> {
+pub fn handle_ui(port: u16, host: Option<IpAddr>, headless: bool) -> Result<()> {
     let mut options = ServerOptions::from_env().with_port(port);
     if let Some(host) = host {
         options = options.with_host(host);
     }
-    if std::env::var("AGENTDEV_AUTO_OPEN_BROWSER").is_err() {
+
+    // Headless mode overrides any environment variable setting
+    if headless {
+        options = options.with_auto_open(false);
+    } else if std::env::var("AGENTDEV_AUTO_OPEN_BROWSER").is_err() {
         options = options.with_auto_open(true);
     }
+
     run_blocking(options)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,9 @@ enum Commands {
         /// Host to bind the web server to (e.g. 0.0.0.0 to allow remote access)
         #[arg(long)]
         host: Option<std::net::IpAddr>,
+        /// Run in headless mode (no auto-open browser)
+        #[arg(long)]
+        headless: bool,
     },
 }
 
@@ -172,7 +175,7 @@ fn main() -> Result<()> {
             name,
         } => handle_start(prompt, agents, name),
         Commands::DeleteTask { task_name } => handle_delete_task_cli(task_name),
-        Commands::Ui { port, host } => handle_ui(port, host),
+        Commands::Ui { port, host, headless } => handle_ui(port, host, headless),
         // Backward-compatible routing
         Commands::Create { name, agent } => handle_create(name, agent),
         Commands::Open { name, agent } => handle_open(name, agent),


### PR DESCRIPTION
Add --headless flag to agentdev ui command to disable automatic browser opening, making it suitable for headless environments. Environment variable `AGENTDEV_AUTO_OPEN_BROWSER` is too implicit.

## Usage

```bash
# Start UI without opening browser
agentdev ui --headless
```

## Screenshot

<img width="1100" height="172" alt="image" src="https://github.com/user-attachments/assets/afe8d637-977b-4148-9a7d-50b6372e7218" />
<img width="1746" height="466" alt="image" src="https://github.com/user-attachments/assets/aa74f442-f0c9-4e8d-a766-05a40e430032" />
